### PR TITLE
Fixes #7 - karma does not want to exit

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -29,11 +29,12 @@ class IEVMLauncher
 
   kill: (done) ->
     # Close the IE window.
-    @vm.close().then =>
+    @vm.close().then(=>
       # Bail out and leave the motor running if it was previously.
       return done() if @wasRunning
       # Stop the vm (saving its state).
       @vm.stop().then => done()
+    ).catch(done)
 
   markCaptured: -> @captured = true
   isCaptured: -> @captured


### PR DESCRIPTION
Whilst debugging this I discovered that kill gets called twice by Karma (unsure why).

Anyway, Virtual Box errors out if you try and stop a box twice, so we catch the error and call done which allows karma to exit. Everything seems to work with this fix applied.

@xdissent you may want to take a look at this, and see if it resolves #7 for you.

@niksy @lucascaro @chemerisuk does this fix #7 for you guys?
